### PR TITLE
Chore/override default headers

### DIFF
--- a/integration/rest_service/providers/clients.py
+++ b/integration/rest_service/providers/clients.py
@@ -40,7 +40,7 @@ class GenericAPIClient(object):
             if not headers:
                 headers = self.get_headers()
                 cache.set(f"shopper-payments-{self.base_url}", headers)
-        self.client.headers.update(headers)
+        self.client.headers = headers
 
     def get_headers(self) -> Dict[str, str]:
         return dict()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setup(
     name="shopper_payments_integration",
-    version="1.1dev",
+    version="1.2dev",
     packages=setuptools.find_packages(),
     license="",
     long_description=open("README.md").read(),


### PR DESCRIPTION
Override headers to use headers returned from `get_headers` method

In this way the headers will be defined in the inherit method instead of override just the key returned
Use
```
{'Authorization': 'bearer 1234'}
```
instead of 
```
{'User-Agent': 'python-requests/2.21.0', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive', 'Authorization': 'bearer 1234'}
```